### PR TITLE
增加文件后缀匹配能力

### DIFF
--- a/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/fauxpas/FauxPasReportParser.java
+++ b/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/fauxpas/FauxPasReportParser.java
@@ -23,6 +23,7 @@ import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
@@ -69,7 +70,9 @@ public class FauxPasReportParser {
     private void recordIssue(final JSONObject diagnosticJson) {
         String filePath = (String) diagnosticJson.get("file");
         if (filePath != null) {
-            FilePredicate fp = context.fileSystem().predicates().hasAbsolutePath(filePath);
+            FilePredicates predicates = context.fileSystem().predicates();
+            FilePredicate fp = predicates.or(predicates.hasAbsolutePath(filePath), predicates.hasRelativePath(filePath) );
+
 
             if (!context.fileSystem().hasFiles(fp)) {
                 LOGGER.warn("file not included in sonar {}", filePath);

--- a/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/oclint/OCLintParser.java
+++ b/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/oclint/OCLintParser.java
@@ -20,6 +20,8 @@ package com.backelite.sonarqube.objectivec.issues.oclint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FilePredicates;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
@@ -85,27 +87,39 @@ final class OCLintParser {
 
     private void collectFileViolations(String filePath, NodeList nodeList) {
         File file = new File(filePath);
-        FilePredicate fp = context.fileSystem().predicates().hasAbsolutePath(file.getAbsolutePath());
-        if(!context.fileSystem().hasFiles(fp)){
-            LOGGER.warn("file not included in sonar {}", filePath);
-        } else {
-            InputFile inputFile = context.fileSystem().inputFile(fp);
-            for (int i = 0; i < nodeList.getLength(); i++) {
-                Node node = nodeList.item(i);
-                if (node.getNodeType() == Node.ELEMENT_NODE) {
-                    Element element = (Element) node;
-                    NewIssueLocation dil = new DefaultIssueLocation()
-                            .on(inputFile)
-                            .at(inputFile.selectLine(Integer.valueOf(element.getAttribute(LINE))))
-                            .message(element.getTextContent());
-                    context.newIssue()
-                            .forRule(RuleKey.of(OCLintRulesDefinition.REPOSITORY_KEY, element.getAttribute(RULE)))
-                            .at(dil)
-                            .save();
+        FilePredicates predicates = context.fileSystem().predicates();
+        FilePredicate fp = predicates.or(predicates.hasAbsolutePath(filePath), predicates.hasRelativePath(filePath));
+
+        InputFile inputFile = null;
+        if (!context.fileSystem().hasFiles(fp)) {
+            FileSystem fs = context.fileSystem();
+            //Search for path _ending_ with the filename
+            for (InputFile f : fs.inputFiles(fs.predicates().hasType(InputFile.Type.MAIN))) {
+                if (filePath.endsWith(f.relativePath())) {
+                    inputFile = f;
+                    break;
                 }
             }
+        } else {
+            inputFile = context.fileSystem().inputFile(fp);
         }
-
-
+        if (inputFile == null) {
+            LOGGER.warn("file not included in sonar {}", filePath);
+            return;
+        }
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            Node node = nodeList.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE) {
+                Element element = (Element) node;
+                NewIssueLocation dil = new DefaultIssueLocation()
+                        .on(inputFile)
+                        .at(inputFile.selectLine(Integer.valueOf(element.getAttribute(LINE))))
+                        .message(element.getTextContent());
+                context.newIssue()
+                        .forRule(RuleKey.of(OCLintRulesDefinition.REPOSITORY_KEY, element.getAttribute(RULE)))
+                        .at(dil)
+                        .save();
+            }
+        }
     }
 }

--- a/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardReportParser.java
+++ b/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardReportParser.java
@@ -20,6 +20,7 @@ package com.backelite.sonarqube.swift.complexity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultInputComponent;
@@ -128,7 +129,9 @@ public class LizardReportParser {
     }
 
     private InputFile getFile(String fileName){
-        FilePredicate fp = context.fileSystem().predicates().hasRelativePath(fileName);
+        FilePredicates predicates = context.fileSystem().predicates();
+        FilePredicate fp = predicates.or(predicates.hasAbsolutePath(fileName), predicates.hasRelativePath(fileName) );
+
         if(!context.fileSystem().hasFiles(fp)){
             LOGGER.warn("file not included in sonar {}", fileName);
             return null;

--- a/swiftlang/src/main/java/com/backelite/sonarqube/swift/issues/swiftlint/SwiftLintReportParser.java
+++ b/swiftlang/src/main/java/com/backelite/sonarqube/swift/issues/swiftlint/SwiftLintReportParser.java
@@ -20,6 +20,8 @@ package com.backelite.sonarqube.swift.issues.swiftlint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FilePredicate;
+import org.sonar.api.batch.fs.FilePredicates;
+import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
@@ -62,21 +64,34 @@ public class SwiftLintReportParser {
             String message = matcher.group(5);
             String ruleId = matcher.group(6);
 
-            FilePredicate fp = context.fileSystem().predicates().hasAbsolutePath(filePath);
+            FilePredicates predicates = context.fileSystem().predicates();
+            FilePredicate fp = predicates.or(predicates.hasAbsolutePath(filePath), predicates.hasRelativePath(filePath));
+
+            InputFile inputFile = null;
             if (!context.fileSystem().hasFiles(fp)) {
+                FileSystem fs = context.fileSystem();
+                //Search for path _ending_ with the filename
+                for (InputFile f : fs.inputFiles(fs.predicates().hasType(InputFile.Type.MAIN))) {
+                    if (filePath.endsWith(f.relativePath())) {
+                        inputFile = f;
+                        break;
+                    }
+                }
+            } else {
+                inputFile = context.fileSystem().inputFile(fp);
+            }
+            if (inputFile == null) {
                 LOGGER.warn("file not included in sonar {}", filePath);
                 continue;
             }
-
-            InputFile inputFile = context.fileSystem().inputFile(fp);
             NewIssueLocation dil = new DefaultIssueLocation()
-                .on(inputFile)
-                .at(inputFile.selectLine(lineNum))
-                .message(message);
+                    .on(inputFile)
+                    .at(inputFile.selectLine(lineNum))
+                    .message(message);
             context.newIssue()
-                .forRule(RuleKey.of(SwiftLintRulesDefinition.REPOSITORY_KEY, ruleId))
-                .at(dil)
-                .save();
+                    .forRule(RuleKey.of(SwiftLintRulesDefinition.REPOSITORY_KEY, ruleId))
+                    .at(dil)
+                    .save();
         }
     }
 }


### PR DESCRIPTION
在使用多阶段的CI任务时候，如果这些任务运行在多个CI-Runner时候，多个阶段生成的oclint、swift、infer的结果是文件的绝对路径与sonar-scanner阶段的路径不一致，导致file not included in sonar。解决方式和findbug插件类似，遍历整个源码文件，匹配文件的后缀