### PR TITLE
修改filePath为file.getAbsolutePath()

### DIFF
--- a/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/oclint/OCLintParser.java
+++ b/objclang/src/main/java/com/backelite/sonarqube/objectivec/issues/oclint/OCLintParser.java
@@ -88,7 +88,7 @@ final class OCLintParser {
     private void collectFileViolations(String filePath, NodeList nodeList) {
         File file = new File(filePath);
         FilePredicates predicates = context.fileSystem().predicates();
-        FilePredicate fp = predicates.or(predicates.hasAbsolutePath(filePath), predicates.hasRelativePath(filePath));
+        FilePredicate fp = predicates.or(predicates.hasAbsolutePath(file.getAbsolutePath()), predicates.hasRelativePath(filePath));
 
         InputFile inputFile = null;
         if (!context.fileSystem().hasFiles(fp)) {


### PR DESCRIPTION
-Dsonar.swift.oclint.report配置为相对路径，可正确识别出坏味道